### PR TITLE
Add support for file-backed flash emulation.

### DIFF
--- a/lpc_reset.c
+++ b/lpc_reset.c
@@ -15,5 +15,20 @@ struct mbox_context;
  */
 int lpc_reset(struct mbox_context *context)
 {
-	return lpc_map_flash(context);
+	if(context->filename)
+	{
+		/*
+		 * We are running from a file instead of /dev/mtd/pnor
+		 * During init, we preloaded the file contents to the
+		 *   memory mapped window, so it's safe to point to mem.
+		*/
+		return lpc_map_memory(context);
+	}
+	else
+	{
+		/*
+		 * We are pointing directly to the flash device,
+		 */
+		return lpc_map_flash(context);
+        }
 }

--- a/mboxd.h
+++ b/mboxd.h
@@ -90,6 +90,8 @@ struct mbox_context {
 	bool current_is_write;
 
 /* Memory & Flash State */
+	/* Backing file */
+	const char* filename;
 	/* Reserved Memory Region */
 	void *mem;
 	/* Reserved Mem Size (bytes) */


### PR DESCRIPTION
When the --file or -i option is passed in from the command line,
   use the passed in file as the backing flash device.
In this mode, replace all ioctl calls with pwrite calls instead.
In this mode, we also assume that the erase size is 4KB.

Note: This mode does *not* emulate writes as we can write to non-erased
   flash areas without issues. To properly emulate writes, a
   read-and-write sequence would be needed.

This code has been tested with a PNOR with invaslid ECC in thee CVPD.
   The firmware is able to properly erase and write to the CVPD.

Signed-off-by: Evan Lojewski <github@meklort.com>